### PR TITLE
Add option to use a subject other than the user ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.1.0
+* Add option to use a subject other than the user ID 
+
 ## v2.0.5
 * Fixes display of LDAP users/groups and provides custom config for the Symfony Ldap-Adapter
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ldap.user.adminQuery: (objectClass=user)
 ldap.user.id: sAMAccountName
 ldap.user.commonName: cn
 ldap.user.groupKey: memberOf
+ldap.user.customSubject: ~ # configure this to use a subject other than the user ID to secure apps, e.g. userPrincipalName
 
 ldap.group.baseDn: ou=groups,dc=example,dc=com
 ldap.group.query: (&(distinguishedName={groupname})(objectClass=group))

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,3 +1,6 @@
+parameters:
+    ldap.user.customSubject: null
+
 services:
     Symfony\Component\Ldap\Ldap:
         arguments: ['@Symfony\Component\Ldap\Adapter\ExtLdap\Adapter']
@@ -53,6 +56,7 @@ services:
             - '%ldap.user.adminQuery%'
             - '%ldap.user.id%'
             - '%ldap.user.commonName%'
+            - '%ldap.user.customSubject%'
 
     ldap.security.subject_domain.group:
         class: Mapbender\LDAPBundle\Security\Permission\SubjectDomainLdapGroup

--- a/Security/Permission/SubjectDomainLdapTrait.php
+++ b/Security/Permission/SubjectDomainLdapTrait.php
@@ -14,13 +14,15 @@ trait SubjectDomainLdapTrait
     protected $query;
     protected $id;
     protected $commonName;
+    protected $customSubject;
 
-    public function __construct(LdapClient $client, $baseDn, $query, $id, $commonName)
+    public function __construct(LdapClient $client, $baseDn, $query, $id, $commonName, $customSubject = null)
     {
         $this->client = $client;
         $this->baseDn = $baseDn;
         $this->query = $query;
         $this->id = $id;
         $this->commonName = $commonName;
+        $this->customSubject = $customSubject;
     }
 }

--- a/Security/Permission/SubjectDomainLdapUser.php
+++ b/Security/Permission/SubjectDomainLdapUser.php
@@ -46,9 +46,11 @@ class SubjectDomainLdapUser extends AbstractSubjectDomain
         $ldapUsers = [];
 
         foreach ($query->execute() as $entry) {
+            $customSubject = (!empty($this->customSubject) && !empty($entry->getAttribute($this->customSubject))) ? $entry->getAttribute($this->customSubject)[0] : null;
             $ldapUsers[] = [
                 'id' => $entry->getAttribute($this->id)[0],
                 'cn' => $entry->getAttribute($this->commonName)[0],
+                'customSubject' => $customSubject,
             ];
         }
 
@@ -59,7 +61,7 @@ class SubjectDomainLdapUser extends AbstractSubjectDomain
                 $this->getIconClass(),
                 null,
                 null,
-                $user['id']
+                (!empty($user['customSubject'])) ? $user['customSubject'] : $user['id'],
             ),
             $ldapUsers
         );


### PR DESCRIPTION
By adding `ldap.user.customSubject` to the LDAP-config in parameters.yaml it is now possible to secure apps and stuff with other than the LDAP-userid (e.g. userPrincipalName / Email):

`ldap.user.customSubject: userPrincipalName`

